### PR TITLE
Add Feature Policy integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,8 @@
         Creates a new <a>Profiler</a> associated with a newly started <a>profiling session</a>. It MUST run these steps:
         </p>
         <ol>
-          <li>If <var>options</var>' <a>ProfilerInitOptions.sampleInterval</a> is less than 0, throw a <code>RangeError</code>.</li>
+          <li>If <var>options</var>' <a>ProfilerInitOptions.sampleInterval</a> is less than 0, reject the promise with a <code>RangeError</code>.</li>
+          <li>If the requesting document's origin is not allowed to use the <code>"js-profiling"</code> <dfn data-cite="!feature-policy-1#feature-policy">feature policy</dfn>, reject the promise with a <code>"SecurityError"</code> DOMException.</li>
           <li>Create a new <a>profiling session</a> where:</li>
           <ol>
             <li>The associated <a>global object</a> is set to the <dfn data-cite="!HTML5#current">current</dfn> global object.</li>
@@ -302,6 +303,25 @@
           <li>Return a <code>Promise</code> that yields a <a>Profiler</a> instance once the <a>profiling session</a> has started.</li>
         </ol>
       </section>
+    </section>
+    <section id="feature-policy">
+      <h2>Feature Policy</h2>
+      <p>
+      This specification defines a new <dfn data-cite="!feature-policy-1#policy-controlled-feature">policy-controlled feature</dfn> that controls whether the <a>Performance.profile</a> method may be invoked.
+      </p>
+      <p>
+      The feature identifier for this feature is <code>"js-profiling"</code>.
+      </p>
+      <p>
+      The <dfn data-cite="!feature-policy-1#default-allowlist">default allowlist</dfn> for this feature is <code>"none"</code>.
+      </p>
+      <p class="note">
+      Feature policy is leveraged here to give embedders the ability to control
+      whether or not embedded frames may start profilers, as well as hint to
+      the UA that the page may wish to initialize profiling. The default policy
+      is false to allow JS engines to avoid storing any profiling metadata for
+      documents that do not intend to profile themselves.
+      </p>
     </section>
     <section id="privacy-security" class="informative">
       <h2>Privacy and Security</h2>


### PR DESCRIPTION
As discussed in the Web Perf WG, we should gate the profiling API behind
a policy-controlled feature. This enables more fine-grained control over
embedders' use of the profiling API, as well as provides a signal to the
JS VM about whether or not profiling may be used.