### PR TITLE
Make performance.profile() return a Profiler synchronously

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <section class="informative">
         <h2>Examples</h2>
         <pre class="example">
-        const profiler = await performance.profile({ sampleInterval: 10 });
+        const profiler = performance.profile({ sampleInterval: 10 });
         for (let i = 0; i &lt; 1000000; i++) {
              doWork();
         }
@@ -307,7 +307,7 @@
       <pre class="idl">
       [Exposed=Window]
       partial interface Performance {
-        Promise&lt;Profiler&gt; profile(ProfilerInitOptions options);
+        Profiler profile(ProfilerInitOptions options);
       };
       </pre>
       <section>
@@ -316,15 +316,15 @@
         Creates a new <a>Profiler</a> associated with a newly started <a>profiling session</a>. It MUST run these steps:
         </p>
         <ol>
-          <li>If <var>options</var>' {{ProfilerInitOptions/sampleInterval}} is less than 0, reject the promise with a <code>RangeError</code>.</li>
-          <li><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get the policy value</a> for <code>"js-profiling"</code> in the <a data-cite="!HTML5#document">Document</a>. If the result is false, reject the promise with a <code>"NotAllowedError"</code> DOMException.</li>
+          <li>If <var>options</var>' {{ProfilerInitOptions/sampleInterval}} is less than 0, throw a <code>RangeError</code>.</li>
+          <li><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get the policy value</a> for <code>"js-profiling"</code> in the <a data-cite="!HTML5#document">Document</a>. If the result is false, throw a <code>"NotAllowedError"</code> DOMException.</li>
           <li>Create a new <a>profiling session</a> where:</li>
           <ol>
             <li>The associated <a>sample interval</a> is set to either <a>ProfilerInitOptions.sampleInterval</a> OR the next lowest interval supported by the UA.</li>
             <li>The associated <a>time origin</a> is equal to the time origin of the <dfn data-cite="!HTML5#current">current</dfn> global object.</li>
             <li>The associated <a>ProfilerTrace</a> is created with size <var>options</var>' {{ProfilerInitOptions/maxBufferSize}}.</li>
           </ol>
-          <li>Return a <code>Promise</code> that yields a <a>Profiler</a> instance once the <a>profiling session</a> has started.</li>
+          <li>Return a new <a>Profiler</a> associated with the newly created <a>profiling session</a>.</li>
         </ol>
       </section>
     </section>


### PR DESCRIPTION
As per #37, it's not necessary nor desirable for a profiler to be
returned asynchronously from performance.profile. The use of document policy permits earlier warmup work to occur if necessary.