### PR TITLE
Require included builtins to be invoked by accessible script

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,27 +174,41 @@
       To <dfn>get a frame ID</dfn> given an <dfn data-cite="!ECMA-262#sec-execution-contexts">execution context</dfn> bound to <var>context</var>, perform the following steps:
       <ol>
         <li>If the [= realm =] associated with <var>context</var> does not match the realm associated with the profiling session, return <code>undefined</code>.</li>
-        <li>Let <var>frame</var> be a new <a>ProfilerFrame</a>.</li>
         <li>Let <var>instance</var> be equal to the <dfn data-cite="!ECMA-262#sec-function-instances">function instance</dfn> associated with <var>context</var>.</li>
-        <li>Set <a>ProfilerFrame.name</a> of <var>frame</var> to the <dfn data-cite="!ECMA-262#sec-function-instances-name">function instance name</dfn> associated with |instance|.</li>
         <li>Let <var>scriptOrModule</var> be equal to the <code>ScriptOrModule</code> associated with <var>context</var>.</li>
         <li>
-          If |scriptOrModule| is non-null:
+          Let |attributedScriptOrModule : ScriptOrModule| be equal to the result of running the following algorithm:
+          <ol>
+            <li>If |scriptOrModule| is non-null, return |scriptOrModule|.</li>
+            <li>If |instance| is a built-in function object, return the <code>ScriptOrModule</code> containing the function that invoked |instance|.
+              <p class="ednote">
+              The purpose of the above logic is to ensure that built-in functions invoked by inaccessible scripts are not exposed in traces, by using the <code>ScriptOrModule</code> that invoked them for attribution.
+              </p>
+              <p class="issue">
+              "[...] the <code>ScriptOrModule</code> containing the function that invoked |instance|" should be defined more rigorously. We could leverage the top-most execution context on the stack that defines a <code>ScriptOrModule</code> to provide this, but it's not ideal -- there may (theoretically) be other mechanisms for a builtin to be enqueued on the execution context stack, in which case the attribution would be invalid.
+              </p>
+            </li>
+            <li>Otherwise, return null.</li>
+          </ol>
+        </li>
+        <li>If |attributedScriptOrModule| is null, return <code>undefined</code>.</li>
+        <li>Let |attributedScript : Script| be the [= script =] obtained from |attributedScriptOrModule|.[[\HostDefined]].</li>
+        <li>
+          If |attributedScript| is a [= classic script =] and its <dfn data-cite="HTML5#muted-errors">muted errors</dfn> boolean is equal to <code>true</code>, return <code>undefined</code>.
           <p class="ednote">
-          Builtin functions have a null <code>ScriptOrModule</code>.
-          </p>
+          This check ensures that we avoid including stack frames from cross-origin scripts served in a CORS-cross-origin response. We may want to consider renaming <a>muted errors</a> to better reflect this use case.
+          <p>
+        </li>
+        <li>Let <var>frame</var> be a new <a>ProfilerFrame</a>.</li>
+        <li>Set <a>ProfilerFrame.name</a> of <var>frame</var> to the <dfn data-cite="!ECMA-262#sec-function-instances-name">function instance name</dfn> associated with |instance|.</li>
+        <li>
+          If |scriptOrModule| is non-null:
           <ol>
             <li>Let <var>script</var> be the <dfn data-cite="HTML5#concept-script">script</dfn> obtained from <var>scriptOrModule</var>.[[\HostDefined]].</li>
-            <li>
-              If <var>script</var> is a <dfn data-cite="HTML5#classic-script">classic script</dfn> and its <dfn data-cite="HTML5#muted-errors">muted errors</dfn> boolean is equal to <code>true</code>, return <code>null</code>.
-              <p class="ednote">
-              This check ensures that we avoid including stack frames from cross-origin scripts served in a CORS-cross-origin response. We may want to consider renaming <a>muted errors</a> to better reflect this use case.
-              <p>
-            </li>
             <li>Let <var>resourceString</var> be equal to the <dfn data-cite="HTML5#concept-script-base-url">base URL</dfn> of <var>script</var>.</li>
             <li>Set <a>ProfilerFrame.resourceId</a> to the result of running <a>get an element ID</a> on <var>resourceString</var> and <a>ProfilerTrace.resources</a>.</li>
-            <li>Set <a>ProfilerFrame.line</a> of <var>frame</var> to the 1-based index of the line at which <var>instance</var> is defined in its containing script.</li>
-            <li>Set <a>ProfilerFrame.column</a> of <var>frame</var> to the 1-based index of the column at which <var>instance</var> is defined in its containing script.</li>
+            <li>Set <a>ProfilerFrame.line</a> of <var>frame</var> to the 1-based index of the line at which <var>instance</var> is defined in |script|.</li>
+            <li>Set <a>ProfilerFrame.column</a> of <var>frame</var> to the 1-based index of the column at which <var>instance</var> is defined in |script|.</li>
           </ol>
         <li>Return the result of running <a>get an element ID</a> on <var>frame</var> and <a>ProfilerTrace.frames</a>.</li>
       </ol>
@@ -403,7 +417,7 @@
       <section>
         <h2>Cross-origin script contents</h2>
         <p>
-        The API avoids exposing contents of cross-origin scripts by requiring all functions included via the <a>take a sample</a> algorithm to be defined in a script served with <dfn data-cite="HTML5#cors-same-origin">CORS-same-origin</dfn> through the <a>muted errors</a> property. Browser builtins (such as <code>performance.now()</code>) may still be included when invoked from cross-origin no-cors script (albeit with no information about the invoking script, line, or column number), although this is already made possible through manually overriding global objects.
+        The API avoids exposing contents of cross-origin scripts by requiring all functions included via the <a>take a sample</a> algorithm to be defined in a script served with <dfn data-cite="HTML5#cors-same-origin">CORS-same-origin</dfn> through the <a>muted errors</a> property. Browser builtins (such as <code>performance.now()</code>) must also only be included when invoked from [= CORS-same-origin =] script.
         </p>
         <p>
         As a result, the API does not expose any new insight into the contents or execution characteristics of cross-origin script, beyond what is already possible through manual instrumentation. UAs are encouraged to verify this holds if they choose to support extremely low <a>sample interval</a> values (e.g. less than one millisecond).


### PR DESCRIPTION
Update the processing model to reference the non-normative caller of
built-ins to determine the ScriptOrModule to use for attribution. This
ensures that we no longer leak function invocations from no-CORS script.

Fixes #51.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/js-self-profiling/pull/52.html" title="Last updated on Aug 4, 2021, 9:43 PM UTC (91c536d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/js-self-profiling/52/52a0a6c...91c536d.html" title="Last updated on Aug 4, 2021, 9:43 PM UTC (91c536d)">Diff</a>