### PR TITLE
Add Parser and Compile marker

### DIFF
--- a/markers.md
+++ b/markers.md
@@ -64,6 +64,10 @@ But we can envision 3 markers corresponding to the stages described in draft doc
 * `layout`
 * `paint`
 
+Additionaly UAs may support additional markers they consider relevant for performance analysis on their platform. Examples of those markers are:
+
+* `script-parser`:  script related activity, converting a script into an intermediate representation like an Abstract Syntax Tree
+* `script-compile`: script related activity, converting a script into a bytecode representation for execution.
 
 ```
 enum ProfilerMarker { "script", "gc", "style", "layout", "paint", "other" };


### PR DESCRIPTION
Addresses https://github.com/WICG/js-self-profiling/issues/71

Adds support for optional markers that UAs may implement to help assessing performance on their platform.

Example of these markers are JS parser and compile that are supported by most engines but not in the spec.