### PR TITLE
Remove Document-Policy header requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ Finally, several other Web properties with large codebases have expressed intere
 
 ## API Overview
 
-Before developers can make use of the profiler, they'll first have to signal to the UA that they wish to profile by exposing the `Document-Policy: js-profiling` header.
-
-> This header ensures that any UA-specific profiling overhead is incurred only on loads that may profile.
-
-Developers will then be able to spin up a new `profiler` via `new Profiler(options)`, where `options` contains the following required fields:
+Developers can start a new profiler with `new Profiler(options)`, where `options` contains the following required fields:
 
 - `sampleInterval`: Target sample rate (in ms per sample)
   - The UA may choose a different sample rate than the one that the user requested (which must be the next lowest valid sampling interval).

--- a/index.html
+++ b/index.html
@@ -245,7 +245,6 @@
         <a>new Profiler(options)</a> runs the following steps given an object <var>options</var> of type <a>ProfilerInitOptions</a>:
         <ol>
             <li>If <var>options</var>' {{ProfilerInitOptions/sampleInterval}} is less than 0, throw a <code>RangeError</code>.</li>
-            <li><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get the policy value</a> for <code>"js-profiling"</code> in the <a data-cite="!HTML5#document">Document</a>. If the result is false, throw a <code>"NotAllowedError"</code> DOMException.</li>
             <li>Create a new <a>profiling session</a> where:</li>
             <ol>
               <li>The associated <a>sample interval</a> is set to either <a>ProfilerInitOptions.sampleInterval</a> OR the next lowest interval supported by the UA.</li>
@@ -355,22 +354,6 @@
         <li><dfn>sampleInterval</dfn> is the application's desired <a>sample interval</a>. This value MUST be greater than or equal to zero.</li>
         <li><dfn>maxBufferSize</dfn> is the desired <a>sample buffer size limit</a>, in samples.</li>
       </ul>
-    </section>
-    <section id="document-policy">
-      <h2>Document Policy</h2>
-      <p>
-      This spec defines a <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point">configuration point</a> in <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html">Document Policy</a> with name <code>js-profiling</code>. Its <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-type">type</a> is <code>boolean</code> with <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-default-value">default value</a> <code>false</code>.
-      </p>
-      <p class="note">
-      Document policy is leveraged to give UAs the ability to avoid storing
-      required metadata for profiling when the document does not explicitly
-      request it.  While this metadata could conceivably be generated in
-      response to a profiler being started, we store this bit on the document
-      in order to signal to the engine as early as possible (as profiling early
-      in page load is a common use case). This overhead may be non-trivial
-      depending on the implementation, and therefore we default to
-      <code>false</code>.
-      </p>
     </section>
     <section>
       <h2>Automation</h2>


### PR DESCRIPTION
Discussions with @acomminos lead me to believe that the Document-Policy header requirement is superfluous and we can instead launch the profiler lazily when the first `new Profiler` is created.

Currently, the requirement to enable js-profiling with the `Document-Policy` header forces authors to decide whether JS profiling will be available on the server side at page load time, which has several downsides:
1. The server may not have information about whether profiling will be needed in the client at page load time. The header could be attached unconditionally, but this forces the browser to do extra work to collect profiling information even though it won't be used.
2. Pages served from file:// or through some CDNs cannot have this header attached, making it impossible to use the self-profiling API on these pages.

The header was initially introduced because of a mistaken belief that launching the profiler before pageload would result in a faster profiler startup time because the JS heap would be empty to begin with, and profiling metadata collection could be amortized as functions were parsed and added to the heap. This is true for some initial page loads, but if Chromium has a code cache for a page (i.e. if it's not a first-load), that cache will be loaded into the heap before the profiler begins, which is just as much work as if the profiler were started later, so this benefit is questionable. The cost of this initial load was missed at design time because it happens very early in page load (before any JS runs!) and so was difficult to measure.