### PR TITLE
feat: Add conditional marker exposure based on cross-origin isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ window.addEventListener('load', collectAndSendTrace);
 
 ## Markers Extensions
 
-See [markers](markers.md) for detailed description of the proposal.
+The API supports optional markers that identify browser activity during sampling. Markers are conditionally exposed based on security context - all markers are available in cross-origin isolated contexts, while only safe markers (`style`, `layout`) are available in regular contexts.
+
+See [markers](markers.md) for detailed description of the proposal and [Conditional Markers Exposure](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ConditionalMarkersExposure/explainer.md) for technical implementation details.
 
 ## Privacy and Security
 

--- a/index.html
+++ b/index.html
@@ -303,17 +303,23 @@
       Inspired by the <a href="https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#">V8 trace event format</a>
       and <a href="https://github.com/devtools-html/perf.html/blob/master/docs-developer/gecko-profile-format.md">Gecko profile format</a>,
       this representation is designed to be easily and efficiently serializable.
-      </p>
-      <section data-dfn-for="ProfilerSample" data-link-for="ProfilerSample">
+      </p>      <section data-dfn-for="ProfilerSample" data-link-for="ProfilerSample">
         <h2>The <dfn>ProfilerSample</dfn> Dictionary</h2>
         <pre class="idl">
+        enum ProfilerMarker { "script", "gc", "style", "layout", "paint", "other" };
+
         dictionary ProfilerSample {
           required DOMHighResTimeStamp timestamp;
           unsigned long long stackId;
+          ProfilerMarker? marker;
         };
         </pre>
         <p><dfn>timestamp</dfn> MUST return the value it was initialized to.</p>
         <p><dfn>stackId</dfn> MUST return the value it was initialized to.</p>
+        <p><dfn>marker</dfn> MUST return the value it was initialized to, if present. The availability of markers depends on the context's cross-origin isolation status.</p>
+        <p class="note">
+        In cross-origin isolated contexts, all marker types are available. In non-isolated contexts, only <code>style</code> and <code>layout</code> markers are exposed for security reasons.
+        </p>
       </section>
       <section data-dfn-for="ProfilerStack" data-link-for="ProfilerStack">
         <h2>The <dfn>ProfilerStack</dfn> Dictionary</h2>


### PR DESCRIPTION
feat: Add conditional marker exposure based on cross-origin isolation

Enable selective marker disclosure based on security context:
- COI contexts: all markers (gc, script, paint, layout, style, other)
- Regular contexts: safe markers only (layout, style)

This allows access to layout/style timing (already available via DOM APIs)
in regular contexts while protecting sensitive timing information.

Maintains full backward compatibility with existing API surface.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/HeathcliffAC/js-self-profiling/pull/85.html" title="Last updated on Jun 18, 2025, 10:00 PM UTC (b199482)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/js-self-profiling/85/f7ba71f...HeathcliffAC:b199482.html" title="Last updated on Jun 18, 2025, 10:00 PM UTC (b199482)">Diff</a>